### PR TITLE
Use the system GLFW instead of building glfw-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = ["core"]
 imgui = "0.6.0"
 imgui-opengl-renderer = "0.10.0"
 gl = "0.14.0"
-glfw = "0.41.0"
+glfw = { version = "0.41.0", default-features = false }
 nds-core = { path = "core" }
 
 [profile.release]

--- a/src/display.rs
+++ b/src/display.rs
@@ -27,8 +27,7 @@ impl Display {
     const SCALE: usize = 1;
 
     pub fn new(imgui: &mut imgui::Context) -> Display {
-        let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
-        glfw.set_error_callback(glfw::FAIL_ON_ERRORS);
+        let glfw = glfw::init(glfw::LOG_ERRORS).unwrap();
 
         let width = (Display::WIDTH * Display::SCALE) as u32;
         let height = 19 + (Display::HEIGHT * Display::SCALE) as u32; // TODO: Don't hardcode main menu bar height


### PR DESCRIPTION
On Linux, this allows the user to pick Wayland instead of X11 as their windowing protocol of choice.